### PR TITLE
Move all devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,14 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "browser-sync": "^2.12.3",
+    "eslint-plugin-react": "^5.2.2",
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^3.1.0",
     "gulp-concat": "^2.6.0",
+    "gulp-eslint": "^3.0.1",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-stylus": "^2.3.1",
+    "json-server": "^0.8.16",
     "metrics-graphics": "^2.9.0",
     "nib": "^1.1.0",
     "react": "^15.0.1",
@@ -24,10 +27,5 @@
     "react-router": "^2.0.0",
     "redux": "^3.5.2",
     "webpack-stream": "^3.1.0"
-  },
-  "devDependencies": {
-    "eslint-plugin-react": "^5.2.2",
-    "gulp-eslint": "^3.0.1",
-    "json-server": "^0.8.16"
   }
 }


### PR DESCRIPTION
The most recent Heroku deploy failed. Heroku runs `gulp build` to build
the application. This process fails because the Gulpfile imports some
`devDependencies`, which Heroku doesn't install.

This change makes all `devDependencies` normal `dependencies` instead.
Alternatively, we could separate development tasks into a separate
Gulpfile.
