### PR TITLE
Update front-end dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,13 +5,13 @@
     "postinstall": "gulp build"
   },
   "dependencies": {
-    "axios": "^0.12.0",
+    "axios": "^0.13.1",
     "babel-core": "^6.7.7",
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "browser-sync": "^2.12.3",
-    "eslint-plugin-react": "^5.2.2",
+    "eslint-plugin-react": "^6.0.0",
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^3.1.0",
     "gulp-concat": "^2.6.0",


### PR DESCRIPTION
"npm outdated" reported that these packages had newer versions
available. I don't know of any features from the newer versions that we
need right now, but we might as well stay on top of it.
