### PR TITLE
Remove example chart description

### DIFF
--- a/distributionviewer/core/static/css/chart-detail.styl
+++ b/distributionviewer/core/static/css/chart-detail.styl
@@ -1,6 +1,8 @@
 @import 'lib';
 
 .chart-detail {
+  width: 100%;
+
   .chart {
     height: 60vh;
     margin: $med-padding auto $lrg-padding;

--- a/distributionviewer/core/static/js/app/components/views/chart-detail.js
+++ b/distributionviewer/core/static/js/app/components/views/chart-detail.js
@@ -25,8 +25,6 @@ export class ChartDetail extends React.Component {
       <div className="chart-detail">
         {outliersToggle}
         <ChartContainer isDetail={true} chartId={this.props.params.chartId} chartName={this.props.params.metricName} showOutliers={this.state.showOutliers} />
-        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur at odio egestas, molestie velit ac, sodales nisi. In faucibus quis nunc ac sagittis.</p>
-        <p>Praesent at placerat nisi. Etiam consectetur quis erat id tempus. Nulla tincidunt sapien sit amet accumsan suscipit. Donec leo sem, scelerisque et vehicula vehicula, fermentum vitae nulla. Quisque neque dui, pharetra quis purus sed, semper finibus mauris. Suspendisse potenti.</p>
       </div>
     );
   }


### PR DESCRIPTION
This was fine when we were building a prototype, but now that we're
starting to get real data we should really get rid of it.
