### PR TITLE
Fix #54: Fix floating-point x-axis labels

### DIFF
--- a/distributionviewer/core/static/js/app/components/views/chart.js
+++ b/distributionviewer/core/static/js/app/components/views/chart.js
@@ -65,7 +65,7 @@ export class Chart extends React.Component {
 
     for (let i = 0; i < dataPoints.length; i++) {
       pointsMeta.push({
-        x: dataPoints[i]['refRank'] || dataPoints[i]['b'],
+        x: dataPoints[i]['refRank'] || parseFloat(dataPoints[i]['b']),
         y: dataPoints[i]['c'] * 100,
         p: dataPoints[i]['p'] * 100,
         label: dataPoints[i]['b']

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "gulp-sourcemaps": "^1.6.0",
     "gulp-stylus": "^2.3.1",
     "json-server": "^0.8.16",
-    "metrics-graphics": "^2.10.0",
+    "metrics-graphics": "^2.10.1",
     "nib": "^1.1.0",
     "react": "^15.0.1",
     "react-dom": "^15.0.1",


### PR DESCRIPTION
Version 2.10.1 of metrics-graphics fixed this issue about a week ago,
but we didn't see the benefit because we were inadvertently passing
x-axis values as strings.
