### PR TITLE
Wrap rows of chart rollover table in <tbody>

### DIFF
--- a/distributionviewer/core/static/js/app/components/views/chart.js
+++ b/distributionviewer/core/static/js/app/components/views/chart.js
@@ -50,18 +50,20 @@ export class Chart extends React.Component {
       <div className={`chart is-fetching chart-${this.props.chartId}`}>
         <Fetching />
         <table className="chart-rollover-table">
-          <tr>
-            <th>x</th>
-            <td className="value-x" />
-          </tr>
-          <tr>
-            <th>y</th>
-            <td className="value-y" />
-          </tr>
-          <tr>
-            <th>proportion</th>
-            <td className="value-p" />
-          </tr>
+          <tbody>
+            <tr>
+              <th>x</th>
+              <td className="value-x" />
+            </tr>
+            <tr>
+              <th>y</th>
+              <td className="value-y" />
+            </tr>
+            <tr>
+              <th>proportion</th>
+              <td className="value-p" />
+            </tr>
+          </tbody>
         </table>
       </div>
     );


### PR DESCRIPTION
React has been complaining about the &lt;tbody&gt; not being present. It is
valid to omit it, but apparently doing so can interfere with React down
the road.[1]

[1] https://github.com/facebook/react/issues/5652
