### PR TITLE
Fix #98: Compress JavaScript

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -14,7 +14,15 @@ module.exports = {
     sourceMapFilename: './distributionviewer/core/static/js/bundle.map'
   },
   devtool: '#source-map',
-  plugins: [environmentVariables],
+  plugins: [
+    environmentVariables,
+    new webpack.optimize.UglifyJsPlugin({
+      comments: false,
+      compress: {
+        warnings: false
+      }
+    }),
+  ],
   module: {
     loaders: [
       {


### PR DESCRIPTION
The compressed bundle is 36.5% the size of the uncompressed bundle.
