### PR TITLE
Add helping text for auth

### DIFF
--- a/distributionviewer/core/static/css/login.styl
+++ b/distributionviewer/core/static/css/login.styl
@@ -1,3 +1,5 @@
+@import 'lib';
+
 #login {
   main {
     width: 100%;
@@ -6,6 +8,11 @@
 
   p {
     text-align: center;
+
+  }
+  .auth-help {
+    padding-top: $med-padding;
+    font-size: 11px;
   }
 }
 

--- a/distributionviewer/core/templates/distributionviewer/login.html
+++ b/distributionviewer/core/templates/distributionviewer/login.html
@@ -18,9 +18,12 @@
         </header>
         <main>
           {% if request.GET.status == '403' %}
-            <p class="error">Must log in with a mozilla.com email address</p>
+            <p class="error">Must log in with a mozilla.com Google account</p>
           {% endif %}
-          <p>Please <span class="g-signin2" data-onsuccess="performSignIn">Sign in</span> to continue</p>
+          <p>Please <span class="g-signin2" data-onsuccess="performSignIn">Sign in</span> with your <strong>@mozilla.com</strong> Google account to continue</p>
+          <p class="auth-help">
+            NOTE: If your browser is set to not accept third-party cookies, you will need to allow "https://accounts.google.com" in your list of exceptions to log in.
+          </p>
         </main>
       </div>
     </div>


### PR DESCRIPTION
If you have design preferences I'm happy to adjust or merge fix after.

Here's what this looks like currently:
<img width="1400" alt="screenshot 2016-10-11 10 18 34" src="https://cloud.githubusercontent.com/assets/1106/19280793/326a9f64-8f9c-11e6-96d1-52fde6808715.png">
