### PR TITLE
Add polyfills for Array.from and Object.assign

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "browser-sync": "^2.12.3",
+    "core-js-webpack-plugin": "^1.0.3",
     "d3-array": "^1.0.1",
     "d3-axis": "^1.0.3",
     "d3-format": "^1.0.2",

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -1,12 +1,18 @@
 import path from 'path';
 import webpack from 'webpack';
+import CoreJsPlugin from 'core-js-webpack-plugin';
 
 const plugins = [
   new webpack.DefinePlugin({
     'process.env': {
       'NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development')
     }
-  })
+  }),
+
+  // Polyfills
+  new CoreJsPlugin({
+    modules: ['es6.array.from', 'es6.object.assign'],
+  }),
 ];
 
 // Debugging is a bit tricker when the bundle is compressed, so only compress it


### PR DESCRIPTION
No versions of Internet Explorer support these methods.
