### PR TITLE
Fix #8: Add log option for supported datasets

### DIFF
--- a/distributionviewer/core/static/css/chart-detail.styl
+++ b/distributionviewer/core/static/css/chart-detail.styl
@@ -14,4 +14,16 @@
     text-align: center;
     font-weight: 100;
   }
+
+  .options {
+    display: flex;
+
+    & > * {
+      margin-right: $lrg-padding;
+    }
+
+    .scale label {
+       margin-right: $min-padding;
+    }
+  }
 }

--- a/distributionviewer/core/static/js/app/components/containers/chart-axis-container.js
+++ b/distributionviewer/core/static/js/app/components/containers/chart-axis-container.js
@@ -27,7 +27,7 @@ export default class extends React.Component {
           }
         });
       } else {
-        axis.ticks(3);
+        axis.ticks(3, ',d');
       }
       axisElm.attr('transform', `translate(0, ${props.size})`).call(axis);
     } else {

--- a/distributionviewer/core/static/js/app/components/views/chart-detail.js
+++ b/distributionviewer/core/static/js/app/components/views/chart-detail.js
@@ -6,14 +6,28 @@ import DescriptionContainer from '../containers/description-container';
 
 export default function(props) {
   let outliersToggle = '';
+  let scaleOption = '';
+
   if (props.offerOutliersToggle) {
-    outliersToggle = <label className="show-outliers"><input type="checkbox" defaultChecked={props.showOutliers} onChange={props.toggleOutliers} />Show outliers</label>
+    outliersToggle = <label className="show-outliers"><input type="checkbox" defaultChecked={props.showOutliers} onChange={props.toggleOutliers} />Show outliers</label>;
+  }
+
+  if (props.offerScaleOption) {
+    scaleOption = (
+      <div className="scale">
+        <label><input type="radio" name="scale" value="linear" checked={props.selectedScale === 'linear'} onChange={props.selectScale} />Linear</label>
+        <label><input type="radio" name="scale" value="log" checked={props.selectedScale === 'log'} onChange={props.selectScale} />Log</label>
+      </div>
+    );
   }
 
   return (
     <div id="chart-detail" className="chart-detail">
-      {outliersToggle}
-      <ChartContainer isDetail={true} showOutliers={props.showOutliers} metricId={props.metricId} />
+      <div className="options">
+        {outliersToggle}
+        {scaleOption}
+      </div>
+      <ChartContainer isDetail={true} showOutliers={props.showOutliers} selectedScale={props.selectedScale} metricId={props.metricId} />
       <DescriptionContainer rawDescription={props.rawDescription} asTooltip={false} />
     </div>
   );


### PR DESCRIPTION
Unsupported datasets include non-numerical datasets (for obvious
reasons) and datasets that contain an x-value <= 0, since log is
undefined for numbers <= 0.