### PR TITLE
API: populations.population -> populations.name

### DIFF
--- a/distributionviewer/api/serializers.py
+++ b/distributionviewer/api/serializers.py
@@ -33,7 +33,7 @@ class DistributionSerializer(serializers.Serializer):
                 dataset=obj.dataset, metric=obj.metric,
                 population__in=self.populations):
             data = {
-                'population': pop.population,
+                'name': pop.population,
                 'numObs': pop.num_observations,
             }
             data['points'] = self._point_serializer(pop.points(),

--- a/distributionviewer/core/static/js/app/components/containers/chart-container.js
+++ b/distributionviewer/core/static/js/app/components/containers/chart-container.js
@@ -65,7 +65,7 @@ class ChartContainer extends React.Component {
     // x-axis will need to show different ticks and thus needs to be
     // regenerated.
     if (outliersSettingChanged || selectedScaleChanged) {
-      this.biggestDatasetToShow = this.populationData[this.biggestPopulation.population][this.activeDatasetName];
+      this.biggestDatasetToShow = this.populationData[this.biggestPopulation.name][this.activeDatasetName];
       this.setState({xScale: this._getXScale(this.props, this.state.size.innerWidth)});
     }
   }
@@ -89,11 +89,10 @@ class ChartContainer extends React.Component {
         this.biggestPopulation = population;
       }
 
-      // population.population = the name of this population
-      this.populationData[population.population] = {};
-      this.populationData[population.population][this.allDatasetName] = fmtData;
+      this.populationData[population.name] = {};
+      this.populationData[population.name][this.allDatasetName] = fmtData;
       if (fmtDataExcludingOutliers) {
-        this.populationData[population.population][this.excludingOutliersDatasetName] = fmtDataExcludingOutliers;
+        this.populationData[population.name][this.excludingOutliersDatasetName] = fmtDataExcludingOutliers;
       }
     }
 
@@ -108,7 +107,7 @@ class ChartContainer extends React.Component {
     // outliers.
     //
     // We'll need this when setting the scales.
-    this.biggestDatasetToShow = this.populationData[this.biggestPopulation.population][this.activeDatasetName];
+    this.biggestDatasetToShow = this.populationData[this.biggestPopulation.name][this.activeDatasetName];
 
     this.refLabels = [];
     this.biggestDatasetToShow.map(item => {

--- a/distributionviewer/core/static/js/app/components/views/legend.js
+++ b/distributionviewer/core/static/js/app/components/views/legend.js
@@ -8,8 +8,7 @@ export default function(props) {
   // the last data line shown in charts.
   let all;
   const popAllLast = props.metric.populations.filter(population => {
-    // population.population = the name of this population
-    if (population.population === 'All') {
+    if (population.name === 'All') {
       all = population;
       return false;
     }
@@ -27,7 +26,7 @@ export default function(props) {
                 <line x1="0" y1="5" x2="50" y2="5" strokeWidth="5" />
               </svg>
               <span className="name">
-                {population.population}
+                {population.name}
               </span>
             </li>
           );

--- a/docs/api.md
+++ b/docs/api.md
@@ -52,7 +52,7 @@ Example output:
   "metric": "architecture",
   "populations": [
     {
-      "population": "All",
+      "name": "All",
       "numObs": 5321560,
       "points": [
         {
@@ -107,7 +107,7 @@ Example output:
     <code>DataSet</code>s to exist.
   </dd>
 
-  <dt>population</dt>
+  <dt>populations.name</dt>
   <dd>
     The population this data set applies to. Besides "All", some examples
     include: "channel:release" or "os:darwin".


### PR DESCRIPTION
This is something that came up while implementing the populations
feature. The name population.population ended up being a bit confusing
in the front-end code. This commit renames it to population.name.