### PR TITLE
Fix list_display_links setup error

### DIFF
--- a/distributionviewer/api/admin.py
+++ b/distributionviewer/api/admin.py
@@ -12,6 +12,7 @@ class MetricAdmin(admin.ModelAdmin):
     list_display = ['id', 'name', 'source_name', 'type', 'tooltip', 'description']
     list_editable = list_display
     list_filter = ['type']
+    list_display_links = None
 
     formfield_overrides = {
         models.TextField: {


### PR DESCRIPTION
This fixes the following error, which only happens when Distribution
Viewer is set up for the first time:

    <class 'distributionviewer.api.admin.MetricAdmin'>: (admin.E124) The
    value of 'list_editable[0]' refers to the first field in
    'list_display' ('id'), which cannot be used unless
    'list_display_links' is set.